### PR TITLE
Add fraud-check-service module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ poc-aml-monitoring/
 
 ✅ `transaction-api` deployed with Deployment, Service, Ingress, ConfigMap, and Secret — practicing CKA Core Concepts + Security.
 ✅ transaction-api REST API live on Kubernetes — Dockerized, deployed with ConfigMap & Secret.
+✅ fraud-check-service wired with REST, ConfigMap, Secrets — practicing Scheduling & RBAC.

--- a/fraud-check-service/Dockerfile
+++ b/fraud-check-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY target/fraud-check-service-*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/fraud-check-service/pom.xml
+++ b/fraud-check-service/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>fraud-check-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>fraud-check-service</name>
+    <description>Fraud Check Service</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.3.0</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fraud-check-service/src/main/java/com/example/fraudcheckservice/FraudCheckController.java
+++ b/fraud-check-service/src/main/java/com/example/fraudcheckservice/FraudCheckController.java
@@ -1,0 +1,26 @@
+package com.example.fraudcheckservice;
+
+import com.example.fraudcheckservice.dto.TransactionRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/fraud-check")
+public class FraudCheckController {
+
+    @Value("${fraud.threshold}")
+    private double threshold;
+
+    @PostMapping("/validate")
+    public ResponseEntity<String> validateTransaction(@RequestBody TransactionRequest tx) {
+        if (tx.getAmount() != null && tx.getAmount() > threshold) {
+            System.out.println("Flagged: " + tx);
+            return ResponseEntity.ok("Suspicious");
+        }
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/fraud-check-service/src/main/java/com/example/fraudcheckservice/FraudCheckServiceApplication.java
+++ b/fraud-check-service/src/main/java/com/example/fraudcheckservice/FraudCheckServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.fraudcheckservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FraudCheckServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FraudCheckServiceApplication.class, args);
+    }
+}

--- a/fraud-check-service/src/main/java/com/example/fraudcheckservice/dto/TransactionRequest.java
+++ b/fraud-check-service/src/main/java/com/example/fraudcheckservice/dto/TransactionRequest.java
@@ -1,0 +1,30 @@
+package com.example.fraudcheckservice.dto;
+
+public class TransactionRequest {
+    private String accountId;
+    private Double amount;
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionRequest{" +
+            "accountId='" + accountId + '\'' +
+            ", amount=" + amount +
+            '}';
+    }
+}

--- a/fraud-check-service/src/main/resources/application.yaml
+++ b/fraud-check-service/src/main/resources/application.yaml
@@ -1,0 +1,8 @@
+fraud:
+  threshold: 1000
+
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres-db:5432/aml_audit
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}

--- a/k8s-yamls/fraud-check-service/configmap.yaml
+++ b/k8s-yamls/fraud-check-service/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fraud-check-config
+data:
+  FRAUD_THRESHOLD: "1000"

--- a/k8s-yamls/fraud-check-service/deployment.yaml
+++ b/k8s-yamls/fraud-check-service/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fraud-check-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fraud-check-service
+  template:
+    metadata:
+      labels:
+        app: fraud-check-service
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: special-node
+      containers:
+      - name: fraud-check-service
+        image: your-dockerhub-username/fraud-check-service:latest
+        ports:
+        - containerPort: 8080
+        envFrom:
+        - configMapRef:
+            name: fraud-check-config
+        - secretRef:
+            name: fraud-check-secret

--- a/k8s-yamls/fraud-check-service/secret.yaml
+++ b/k8s-yamls/fraud-check-service/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fraud-check-secret
+type: Opaque
+data:
+  DB_USERNAME: YOUR_BASE64
+  DB_PASSWORD: YOUR_BASE64

--- a/k8s-yamls/fraud-check-service/service.yaml
+++ b/k8s-yamls/fraud-check-service/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fraud-check-service
+spec:
+  selector:
+    app: fraud-check-service
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  type: ClusterIP

--- a/transaction-processor/src/main/java/com/example/transactionprocessor/TransactionConsumer.java
+++ b/transaction-processor/src/main/java/com/example/transactionprocessor/TransactionConsumer.java
@@ -1,8 +1,10 @@
 package com.example.transactionprocessor;
 
 import com.example.transactionprocessor.dto.TransactionRequest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 @Component
 public class TransactionConsumer {
@@ -10,6 +12,12 @@ public class TransactionConsumer {
     @KafkaListener(topics = "transaction-events", groupId = "transaction-group")
     public void consume(TransactionRequest tx) {
         System.out.println("Consumed TX: " + tx);
-        // TODO: Call Fraud-Check Service next
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.postForEntity(
+            "http://fraud-check-service:8080/fraud-check/validate",
+            tx,
+            String.class
+        );
+        System.out.println("Fraud check response: " + response.getBody());
     }
 }


### PR DESCRIPTION
## Summary
- add new fraud-check-service Spring Boot application
- implement simple REST controller with threshold logic
- wire transaction-processor to call fraud-check-service
- provide Kubernetes manifests for deployment
- update README for new service

## Testing
- `mvn -q -f transaction-api/pom.xml test` *(fails: Could not resolve Maven resources plugin)*
- `mvn -q -f transaction-processor/pom.xml test` *(fails: Could not resolve Maven resources plugin)*
- `mvn -q -f fraud-check-service/pom.xml test` *(fails: Could not resolve Maven resources plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6873af6b48ac8327a1afb7bcb0b12fe5