### PR TITLE
Fix missing Spring Web dependency

### DIFF
--- a/transaction-processor/pom.xml
+++ b/transaction-processor/pom.xml
@@ -22,6 +22,11 @@
             <version>${spring.boot.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
             <version>${spring.boot.version}</version>


### PR DESCRIPTION
## Summary
- include `spring-boot-starter-web` for transaction-processor module

## Testing
- `mvn -q test` *(fails: could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6873b31ffcfc8327850b4f3c4b1999c1